### PR TITLE
More stable VRPN names

### DIFF
--- a/VRPN-OpenVR/VRPN-OpenVR.vcxproj
+++ b/VRPN-OpenVR/VRPN-OpenVR.vcxproj
@@ -124,12 +124,14 @@
     <ClCompile Include="vrpn_Tracker_OpenVR.cpp" />
     <ClCompile Include="vrpn_Tracker_OpenVR_Controller.cpp" />
     <ClCompile Include="vrpn_Tracker_OpenVR_HMD.cpp" />
+    <ClCompile Include="vrpn_Tracker_OpenVR_Tracker.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="vrpn_Server_OpenVR.h" />
     <ClInclude Include="vrpn_Tracker_OpenVR.h" />
     <ClInclude Include="vrpn_Tracker_OpenVR_Controller.h" />
     <ClInclude Include="vrpn_Tracker_OpenVR_HMD.h" />
+    <ClInclude Include="vrpn_Tracker_OpenVR_Tracker.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\vendor\vrpn\quat\quatlib.vcxproj">

--- a/VRPN-OpenVR/VRPN-OpenVR.vcxproj.filters
+++ b/VRPN-OpenVR/VRPN-OpenVR.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClCompile Include="vrpn_Tracker_OpenVR.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="vrpn_Tracker_OpenVR_Tracker.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="vrpn_Tracker_OpenVR_HMD.h">
@@ -42,6 +45,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="vrpn_Tracker_OpenVR.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="vrpn_Tracker_OpenVR_Tracker.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/VRPN-OpenVR/vrpn_Server_OpenVR.h
+++ b/VRPN-OpenVR/vrpn_Server_OpenVR.h
@@ -49,6 +49,7 @@ private:
     vrpn_Connection                                                                               *connection;
     std::unordered_map<vr::TrackedDeviceIndex_t, std::unique_ptr<vrpn_Tracker_OpenVR_HMD>>        hmds{};
     std::unordered_map<vr::TrackedDeviceIndex_t, std::unique_ptr<vrpn_Tracker_OpenVR_Controller>> controllers{};
+    std::unordered_map<vr::ETrackedControllerRole, std::unique_ptr<vrpn_Tracker_OpenVR_Controller>> hands{};
     std::unordered_map<vr::TrackedDeviceIndex_t, std::unique_ptr<vrpn_Tracker_OpenVR_Tracker>>    trackers{};
 };
 


### PR DESCRIPTION
The VRPN device name is changed to make it easier to know which device is which, also across computers and configurations. HMDs are named like before but controllers and generic trackers are named after their serial id, e g "openvr/controller/LHR-1FD1E53". Controllers are also exposed under the names "openvr/controller/left" and "openvr/controller/right", respectively, based on their identity in the driver.